### PR TITLE
Correcting missing/empty attributes in .podspec

### DIFF
--- a/MapboxSceneKit.podspec
+++ b/MapboxSceneKit.podspec
@@ -6,8 +6,11 @@ Pod::Spec.new do |s|
   s.version = "0.1.0"
   s.summary = "Scene Kit toolkit for Mapbox."
 
-  s.description  = <<-DESC
-                   DESC
+  s.description  = "Using Swift, bringing our rich 3D terrain into your iOS app is easy. 
+                  SceneKit SDK benefits from Apple’s toolchain and tight integration with 
+                  ARKit. Using Apple's built-in Scene Kit frameworks means you can leverage 
+                  compelling virtual terrain experiences without bloating your app's size."
+
 
   # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
@@ -17,6 +20,7 @@ Pod::Spec.new do |s|
 
   s.author = { "Mapbox" => "mobile@mapbox.com" }
   s.social_media_url = "https://twitter.com/mapbox"
+  s.homepage = "mapbox.com"
 
   # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 


### PR DESCRIPTION
When trying to install the pod via repo url cocoapods surfaced these two errors.

**[!] The `MapboxSceneKit` pod failed to validate due to 2 errors:
    - ERROR | attributes: Missing required attribute `homepage`.
    - ERROR | description: The description is empty.**

After merging this command should work when trying to install the pod via repo url.
`pod 'MapboxSceneKit', :git => 'https://github.com/mapbox/mapbox-scenekit.git', :branch => 'master'`
