### PR TITLE
Fix CocoaPods, Carthage incompatibilities

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,1 @@
 github "mapbox/mapbox-events-ios" ~> 0.4
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 4.0.2

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,0 +1,1 @@
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 4.0.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "4.0.2"
-github "mapbox/mapbox-events-ios" "v0.4.0"
+github "mapbox/mapbox-events-ios" "v0.4.1"

--- a/MapboxSceneKit.podspec
+++ b/MapboxSceneKit.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
-  s.source_files = ["MapboxCoreNavigation/*.swift"]
+  s.source_files = ["MapboxSceneKit/**/*.swift"]
 
   # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Using Swift, bringing our rich 3D terrain into your iOS app is easy. SceneKit SDK benefits from Apple’s toolchain and tight integration with ARKit. Using Apple's built-in Scene Kit frameworks means you can leverage compelling virtual terrain experiences without bloating your app's size.
 
-**Note this SDK is in it's beta phase and will be under heavy development as we move towards our 1.0**
+**Note this SDK is in its beta phase and will be under heavy development as we move towards our 1.0**
 
 ## Requirements
 
@@ -18,7 +18,7 @@ To install Mapbox Scene Kit using [CocoaPods](https://cocoapods.org/):
 
 1. Create a [Podfile](https://guides.cocoapods.org/syntax/podfile.html) with the following specification:
    ```ruby
-   pod 'MapboxSceneKit', '~> 0.1'
+   pod 'MapboxSceneKit', :git => 'https://github.com/mapbox/mapbox-scenekit.git'
    ```
 
 1. Run `pod repo update && pod install` and open the resulting Xcode workspace.
@@ -29,7 +29,7 @@ Alternatively, to install Mapbox SceneKit using [Carthage](https://github.com/Ca
 
 1. Create a [Cartfile](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories) with the following dependency:
    ```cartfile
-   github "mapbox/mapbox-scenekit" ~> 0.1
+   github "mapbox/mapbox-scenekit"
    ```
 
 1. Run `carthage update --platform iOS` to build just the iOS dependencies.
@@ -55,4 +55,4 @@ We welcome feedback and code contributions! Please see [CONTRIBUTING.md](./CONTR
 
 ## License
 
-Mapbox Navigation SDK for iOS is released under the ISC License. See [LICENSE.md](https://github.com/mapbox/mapbox-scenekit/blob/master/LICENSE.md) for details.
+Mapbox SceneKit SDK for iOS is released under the ISC License. See [LICENSE.md](https://github.com/mapbox/mapbox-scenekit/blob/master/LICENSE.md) for details.


### PR DESCRIPTION
Fixed the podspec and cartfiles so that developers can install this library via CocoaPods and Carthage, respectively. Removed version information from the readme, since no release has been tagged yet.

Fixes #3, fixes #8.

/cc @parrots @avi-c