### PR TITLE
Avoid extra copy of MapboxMobileEvents in app bundle

### DIFF
--- a/MapboxSceneKit.xcodeproj/project.pbxproj
+++ b/MapboxSceneKit.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		81293BF720B4A35C0014A17A /* ProgressCompositor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81293BCB20B4A1AE0014A17A /* ProgressCompositor.swift */; };
 		81293BF820B4A35C0014A17A /* TerrainDemoScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81293BD220B4A1AE0014A17A /* TerrainDemoScene.swift */; };
 		81293BFF20B4B3D20014A17A /* MapboxMobileEvents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81293BFD20B4B3C10014A17A /* MapboxMobileEvents.framework */; };
-		81293C0020B4B3D20014A17A /* MapboxMobileEvents.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 81293BFD20B4B3C10014A17A /* MapboxMobileEvents.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		81293C0120B4B4010014A17A /* MapboxMobileEvents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81293BFD20B4B3C10014A17A /* MapboxMobileEvents.framework */; };
 		814D9F2720A48538008E6848 /* ImageBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 814D9F2620A48538008E6848 /* ImageBuilder.swift */; };
 		814F3BD520ADF1B40006DDFD /* MapboxImageAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 814F3BD420ADF1B40006DDFD /* MapboxImageAPI.swift */; };
@@ -54,7 +53,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				81293C0020B4B3D20014A17A /* MapboxMobileEvents.framework in Embed Frameworks */,
 				81293BF120B4A29C0014A17A /* MapboxSceneKit.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -343,7 +341,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Fixed the following build issues in Xcode 10 caused by a redundant entry in the example application’s Copy Frameworks build phase:

```
error: Multiple commands produce '~/Library/Developer/Xcode/DerivedData/MapboxSceneKit-hefwdryezquuwtfqobkovumeulir/Build/Products/Debug-iphonesimulator/Examples.app/Frameworks/MapboxMobileEvents.framework':
1) Target 'Examples' has copy command from '~/hub/mapbox-scenekit/Carthage/Build/iOS/MapboxMobileEvents.framework' to '~/Library/Developer/Xcode/DerivedData/MapboxSceneKit-hefwdryezquuwtfqobkovumeulir/Build/Products/Debug-iphonesimulator/Examples.app/Frameworks/MapboxMobileEvents.framework'
2) That command depends on command in Target 'Examples': script phase “Copy Carthage Dependencies”
warning: ignoring duplicated output file: '~/Library/Developer/Xcode/DerivedData/MapboxSceneKit-hefwdryezquuwtfqobkovumeulir/Build/Products/Debug-iphonesimulator/Examples.app/Frameworks/MapboxMobileEvents.framework' (in target 'Examples')
```

This change removes that manual framework copy in favor of what Carthage’s build script does for both MapboxMobileEvents and the map SDK.

/cc @morgane