### PR TITLE
Dynamically calculate the zoom level for tile fetching.

### DIFF
--- a/Examples/DemoARViewController.swift
+++ b/Examples/DemoARViewController.swift
@@ -100,7 +100,7 @@ final class DemoARViewController: UIViewController, ARSCNViewDelegate, ARSession
             NSLog("Terrain load complete")
         })
 
-        terrainNode.fetchTerrainTexture("mapbox/satellite-v9", zoom: 14, progress: { _, _ in }, completion: { image in
+        terrainNode.fetchTerrainTexture("mapbox/satellite-v9", progress: { _, _ in }, completion: { image in
             NSLog("Texture load complete")
             terrainNode.geometry?.materials[4].diffuse.contents = image
         })

--- a/Examples/DemoExtrusionViewController.m
+++ b/Examples/DemoExtrusionViewController.m
@@ -118,7 +118,7 @@
         NSLog(@"terrain height fetch completed");
     }];
     
-    [_terrainNode fetchTerrainTexture:@"mapbox/satellite-v9" zoom:self.mapView.zoomLevel progress:^(float progress, NSInteger total) {
+    [_terrainNode fetchTerrainTexture:@"mapbox/satellite-v9" progress:^(float progress, NSInteger total) {
     } completion:^(UIImage * _Nullable image) {
         NSLog(@"terrain texture fetch completed");
         self.terrainNode.geometry.materials[4].diffuse.contents = image;

--- a/Examples/DemoHeightmapViewController.swift
+++ b/Examples/DemoHeightmapViewController.swift
@@ -82,7 +82,7 @@ class DemoHeightmapViewController: UIViewController {
         }
 
         let textureFetchHandler = progressHandler.registerForProgress()
-        terrainNode.fetchTerrainTexture(style, zoom: 13, progress: { progress, total in
+        terrainNode.fetchTerrainTexture(style, progress: { progress, total in
             self.progressHandler.updateProgress(handlerID: textureFetchHandler, progress: progress, total: total)
 
         }, completion: { image in

--- a/Examples/DemoPlacementViewController.swift
+++ b/Examples/DemoPlacementViewController.swift
@@ -69,7 +69,7 @@ class DemoPlacementViewController: UIViewController {
         })
 
         let textureFetchHandler = progressHandler.registerForProgress()
-        terrainNode.fetchTerrainTexture("mapbox/satellite-v9", zoom: 14, progress: { progress, total in
+        terrainNode.fetchTerrainTexture("mapbox/satellite-v9", progress: { progress, total in
             progressHandler.updateProgress(handlerID: textureFetchHandler, progress: progress, total: total)
 
         }, completion: { image in

--- a/Examples/DemoStyleViewController.swift
+++ b/Examples/DemoStyleViewController.swift
@@ -57,7 +57,7 @@ class DemoStyleViewController: UIViewController {
 
         self.progressView?.progress = 0.0
         self.progressView?.isHidden = false
-        terrainNode.fetchTerrainTexture(style, zoom: 13, progress: { progress, total in
+        terrainNode.fetchTerrainTexture(style, progress: { progress, total in
             self.progressView?.progress = progress
 
         }, completion: { image in

--- a/MapboxSceneKit/TerrainNode.swift
+++ b/MapboxSceneKit/TerrainNode.swift
@@ -61,7 +61,11 @@ open class TerrainNode: SCNNode {
         metersPerLat = 1 / Math.metersToDegreesForLat(at: maxLon)
         metersPerLon = 1 / Math.metersToDegreesForLon(at: maxLat)
 
-        terrainZoomLevel = TerrainNode.zoomLevelForBounds(minLat: minLat, maxLat: maxLat, minLon: minLon, maxLon: maxLon, tileSize: TerrainNode.rgbTileSize)
+        let maxLocation = CLLocation(latitude: maxLat, longitude: maxLon)
+        let minLocation = CLLocation(latitude: minLat, longitude: minLon)
+        let distance = maxLocation.distance(from: minLocation) / 1000.0
+
+        terrainZoomLevel = TerrainNode.zoomLevelAtLatitude(lat: maxLat - minLat, distance: distance)
 
         let bounding = MapboxImageAPI.tiles(zoom: terrainZoomLevel, latBounds: latBounds, lonBounds: lonBounds, tileSize: TerrainNode.rgbTileSize)
         terrainSize = CGSize(width: CGFloat(bounding.xs.count) * TerrainNode.rgbTileSize.width - bounding.insets.left - bounding.insets.right,
@@ -82,26 +86,15 @@ open class TerrainNode: SCNNode {
         }
     }
 
-    private class func zoomLevelForBounds(minLat: CLLocationDegrees, maxLat: CLLocationDegrees, minLon: CLLocationDegrees, maxLon: CLLocationDegrees, tileSize: CGSize) -> Int {
-        var imageSizeIsTooBig = true
-        var zoomLevel = 22
+    private class func zoomLevelAtLatitude(lat: Double, distance: Double) -> Int
+    {
+        // fit the zoom level to the screen width
+        let screenWidth = Double(UIScreen.main.bounds.size.width)
+        let latitudinalAdjustment = cos(.pi * lat / 180)
+        let earthDiameterInKilometers = 40075.16
+        let arg = earthDiameterInKilometers * screenWidth * latitudinalAdjustment / (distance * 256)
 
-        let latBounds = (minLat, maxLat)
-        let lonBounds = (minLon, maxLon)
-
-        while imageSizeIsTooBig {
-            let bounding = MapboxImageAPI.tiles(zoom: zoomLevel, latBounds: latBounds, lonBounds: lonBounds, tileSize: tileSize)
-
-            let size = bounding.xs.count * Int(tileSize.width) * bounding.ys.count * Int(tileSize.height)
-            imageSizeIsTooBig = size > maxTextureImageSizeInBytes
-
-            // drop the zoom level and try again
-            if (imageSizeIsTooBig) {
-                zoomLevel -= 1
-            }
-        }
-
-        return zoomLevel
+        return Int(round(log(arg)/log(2)))
     }
 
     private func centerPivot() {

--- a/MapboxSceneKit/TerrainNode.swift
+++ b/MapboxSceneKit/TerrainNode.swift
@@ -157,11 +157,12 @@ open class TerrainNode: SCNNode {
      For the simplist usage, you'll want to apply it as the diffuse contents in position 4 (the top): `myRerrainNode.geometry?.materials[4].diffuse.contents = image`.
     **/
     @objc
-    public func fetchTerrainTexture(_ style: String, zoom: Int, progress: MapboxImageAPI.TileLoadProgressCallback? = nil, completion: @escaping MapboxImageAPI.TileLoadCompletion) {
+    public func fetchTerrainTexture(_ style: String, progress: MapboxImageAPI.TileLoadProgressCallback? = nil, completion: @escaping MapboxImageAPI.TileLoadCompletion) {
         let latBounds = self.latBounds
         let lonBounds = self.lonBounds
+        let terrainZoomLevel = self.terrainZoomLevel
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            if let taskID = self?.api.image(forStyle: style, zoomLevel: zoom, minLat: latBounds.0, maxLat: latBounds.1, minLon: lonBounds.0, maxLon: lonBounds.1, progress: progress, completion: completion) {
+            if let taskID = self?.api.image(forStyle: style, zoomLevel: terrainZoomLevel, minLat: latBounds.0, maxLat: latBounds.1, minLon: lonBounds.0, maxLon: lonBounds.1, progress: progress, completion: completion) {
                 self?.pendingFetches.append(taskID)
             }
         }


### PR DESCRIPTION
Dynamically calculate the tile zoom level for fetching tiles of a TerrainNode. Balance the detail with the data transfer amount and resulting CGImage size. Use 1MB as the limit for now.