### PR TITLE
API returns errors with important informations

### DIFF
--- a/Examples/DemoARViewController.swift
+++ b/Examples/DemoARViewController.swift
@@ -96,13 +96,22 @@ final class DemoARViewController: UIViewController, ARSCNViewDelegate, ARSession
         arView!.scene.rootNode.addChildNode(terrainNode)
         terrain = terrainNode
 
-        terrainNode.fetchTerrainHeights(minWallHeight: 50.0, enableDynamicShadows: true, progress: { _, _ in }, completion: {
-            NSLog("Terrain load complete")
+        terrainNode.fetchTerrainHeights(minWallHeight: 50.0, enableDynamicShadows: true, completion: { fetchError in
+            if let fetchError = fetchError {
+                NSLog("Texture load failed: \(fetchError.localizedDescription)")
+            } else {
+                NSLog("Terrain load complete")
+            }
         })
 
-        terrainNode.fetchTerrainTexture("mapbox/satellite-v9", progress: { _, _ in }, completion: { image in
-            NSLog("Texture load complete")
-            terrainNode.geometry?.materials[4].diffuse.contents = image
+        terrainNode.fetchTerrainTexture("mapbox/satellite-v9", progress: { _, _ in }, completion: { image, fetchError in
+            if let fetchError = fetchError {
+                NSLog("Texture load failed: \(fetchError.localizedDescription)")
+            }
+            if image != nil {
+                NSLog("Texture load complete")
+                terrainNode.geometry?.materials[4].diffuse.contents = image
+            }
         })
 
         arView!.isUserInteractionEnabled = true

--- a/Examples/DemoExtrusionViewController.m
+++ b/Examples/DemoExtrusionViewController.m
@@ -114,14 +114,23 @@
     }
     
     [_terrainNode fetchTerrainHeightsWithMinWallHeight:50.0 enableDynamicShadows:YES progress:^(float progress, NSInteger total) {
-    } completion:^{
-        NSLog(@"terrain height fetch completed");
+    } completion:^(NSError * _Nullable fetchError) {
+        if (fetchError) {
+            NSLog(@"Texture load failed: %@", fetchError.localizedDescription);
+        } else {
+            NSLog(@"Terrain load complete");
+        }
     }];
     
     [_terrainNode fetchTerrainTexture:@"mapbox/satellite-v9" progress:^(float progress, NSInteger total) {
-    } completion:^(UIImage * _Nullable image) {
-        NSLog(@"terrain texture fetch completed");
-        self.terrainNode.geometry.materials[4].diffuse.contents = image;
+    } completion:^(UIImage * _Nullable image, NSError * _Nullable fetchError) {
+        if (fetchError) {
+            NSLog(@"Texture load failed: %@", fetchError.localizedDescription);
+        }
+        if (image) {
+            NSLog(@"terrain texture fetch completed");
+            self.terrainNode.geometry.materials[4].diffuse.contents = image;
+        }
     }];
 }
 

--- a/Examples/DemoHeightmapViewController.swift
+++ b/Examples/DemoHeightmapViewController.swift
@@ -68,9 +68,13 @@ class DemoHeightmapViewController: UIViewController {
         progressHandler.updateProgress(handlerID: terrainRendererHandler, progress: 0, total: 1)
         terrainNode.fetchTerrainHeights(minWallHeight: 50.0, progress: { progress, total in
             self.progressHandler.updateProgress(handlerID: terrainFetcherHandler, progress: progress, total: total)
-        }, completion: {
+        }, completion: { fetchError in
+            if let fetchError = fetchError {
+                NSLog("Texture load failed: \(fetchError.localizedDescription)")
+            } else {
+                NSLog("Terrain load complete")
+            }
             self.progressHandler.updateProgress(handlerID: terrainRendererHandler, progress: 1, total: 1)
-            NSLog("Terrain load complete")
         })
 
         applyStyle(styles.first!)
@@ -85,9 +89,14 @@ class DemoHeightmapViewController: UIViewController {
         terrainNode.fetchTerrainTexture(style, progress: { progress, total in
             self.progressHandler.updateProgress(handlerID: textureFetchHandler, progress: progress, total: total)
 
-        }, completion: { image in
-            NSLog("Texture load for \(style) complete")
-            terrainNode.geometry?.materials[4].diffuse.contents = image
+        }, completion: { image, fetchError in
+            if let fetchError = fetchError {
+                NSLog("Texture load failed: \(fetchError.localizedDescription)")
+            }
+            if image != nil {
+                NSLog("Texture load for \(style) complete")
+                terrainNode.geometry?.materials[4].diffuse.contents = image
+            }
         })
     }
 

--- a/Examples/DemoPlacementViewController.swift
+++ b/Examples/DemoPlacementViewController.swift
@@ -61,20 +61,28 @@ class DemoPlacementViewController: UIViewController {
         terrainNode.fetchTerrainHeights(minWallHeight: 50.0, enableDynamicShadows: true, progress: { progress, total in
             progressHandler.updateProgress(handlerID: terrainFetcherHandler, progress: progress, total: total)
 
-        }, completion: {
+        }, completion: { fetchError in
+            if let fetchError = fetchError {
+                NSLog("Texture load failed: \(fetchError.localizedDescription)")
+            } else {
+                NSLog("Terrain load complete")
+            }
             progressHandler.updateProgress(handlerID: terrainRendererHandler, progress: 1, total: 1)
-
             self.addUserPath(to: terrainNode)
-            NSLog("Terrain load complete")
         })
 
         let textureFetchHandler = progressHandler.registerForProgress()
         terrainNode.fetchTerrainTexture("mapbox/satellite-v9", progress: { progress, total in
             progressHandler.updateProgress(handlerID: textureFetchHandler, progress: progress, total: total)
 
-        }, completion: { image in
-            NSLog("Texture load complete")
-            terrainNode.geometry?.materials[4].diffuse.contents = image
+        }, completion: { image, fetchError in
+            if let fetchError = fetchError {
+                NSLog("Texture load failed: \(fetchError.localizedDescription)")
+            }
+            if image != nil {
+                NSLog("Texture load complete")
+                terrainNode.geometry?.materials[4].diffuse.contents = image
+            }
         })
     }
 

--- a/Examples/DemoStyleViewController.swift
+++ b/Examples/DemoStyleViewController.swift
@@ -60,10 +60,15 @@ class DemoStyleViewController: UIViewController {
         terrainNode.fetchTerrainTexture(style, progress: { progress, total in
             self.progressView?.progress = progress
 
-        }, completion: { image in
-            NSLog("Texture load complete")
+        }, completion: { image, fetchError in
+            if let fetchError = fetchError {
+                NSLog("Texture load failed: \(fetchError.localizedDescription)")
+            }
+            if image != nil {
+                NSLog("Texture load complete")
+                terrainNode.geometry?.materials[4].diffuse.contents = image
+            }
             self.progressView?.isHidden = true
-            terrainNode.geometry?.materials[4].diffuse.contents = image
         })
     }
 

--- a/MapboxSceneKit/Tile Fetching/MapboxHTTPAPI.swift
+++ b/MapboxSceneKit/Tile Fetching/MapboxHTTPAPI.swift
@@ -2,6 +2,29 @@ import Foundation
 import UIKit
 import CoreLocation
 
+enum FetchError: Int {
+    case notFound = 404
+    case unknown = 1000
+    static private let errorDomain = "com.mapboxSceneKit.TileFetching.errorDomain"
+    
+    var localizedDescription: String {
+        switch self {
+        case .notFound:
+            return NSLocalizedString("Data for given point was not found on the server", comment: "Description of Not Found error")
+        default:
+            return NSLocalizedString("Unknown error", comment: "Description of Unknown error")
+        }
+    }
+    
+    init(code: Int) {
+        self = FetchError(rawValue: code) ?? .unknown
+    }
+    
+    func toNSError() -> NSError {
+        return NSError(domain: FetchError.errorDomain, code: rawValue, userInfo: [NSLocalizedDescriptionKey: localizedDescription])
+    }
+}
+
 internal final class MapboxHTTPAPI {
     private static var operationQueue: OperationQueue = {
         var operationQueue = OperationQueue()
@@ -17,7 +40,7 @@ internal final class MapboxHTTPAPI {
         accessToken = token
     }
 
-    func tileset(_ tileset: String, zoomLevel z: Int, xTile x: Int, yTile y: Int, format: String, completion: @escaping (_ image: UIImage?) -> Void) -> UUID? {
+    func tileset(_ tileset: String, zoomLevel z: Int, xTile x: Int, yTile y: Int, format: String, completion: @escaping (_ image: UIImage?, _ error: FetchError?) -> Void) -> UUID? {
         guard let url = URL(string: "https://api.mapbox.com/v4/\(tileset)/\(z)/\(x)/\(y).\(format)?access_token=\(accessToken)") else {
             NSLog("Couldn't get URL for fetch task")
             return nil
@@ -26,17 +49,17 @@ internal final class MapboxHTTPAPI {
         let task = HttpRequestOperation(url: url, callback: {  (success, responseCode, data) -> Void in
             guard success, let data = data, let image = UIImage(data: data) else {
                 NSLog("Error downloading tile: \(responseCode)")
-                completion(nil)
+                completion(nil, FetchError(code: responseCode))
                 return
             }
-            completion(image)
+            completion(image, nil)
         }, session: URLSession.shared)
         MapboxHTTPAPI.operationQueue.addOperations([task], waitUntilFinished: false)
 
         return task.taskID
     }
 
-    func style(_ s: String, zoomLevel z: Int, xTile x: Int, yTile y: Int, tileSize: CGSize, completion: @escaping (_ image: UIImage?) -> Void) -> UUID? {
+    func style(_ s: String, zoomLevel z: Int, xTile x: Int, yTile y: Int, tileSize: CGSize, completion: @escaping (_ image: UIImage?, _ error: FetchError?) -> Void) -> UUID? {
         let boundingBox = Math.tile2BoundingBox(x: x, y: y, z: z)
         let centerLat = boundingBox.latBounds.1 - (boundingBox.latBounds.1 - boundingBox.latBounds.0) / 2.0
         let centerLon = boundingBox.lonBounds.1 - (boundingBox.lonBounds.1 - boundingBox.lonBounds.0) / 2.0
@@ -44,7 +67,7 @@ internal final class MapboxHTTPAPI {
         return style(s, zoomLevel: z, centerLat: centerLat, centerLon: centerLon, tileSize: tileSize, completion: completion)
     }
 
-    func style(_ style: String, zoomLevel z: Int, centerLat: CLLocationDegrees, centerLon: CLLocationDegrees, tileSize: CGSize, completion: @escaping (_ image: UIImage?) -> Void) -> UUID? {
+    func style(_ style: String, zoomLevel z: Int, centerLat: CLLocationDegrees, centerLon: CLLocationDegrees, tileSize: CGSize, completion: @escaping (_ image: UIImage?, _ error: FetchError?) -> Void) -> UUID? {
         guard let url = URL(string: "https://api.mapbox.com/styles/v1/\(style)/static/\(centerLon),\(centerLat),\(z)/\(Int(tileSize.width))x\(Int(tileSize.height))?access_token=\(accessToken)&attribution=false&logo=false") else {
             NSLog("Couldn't get URL for fetch task")
             return nil
@@ -54,10 +77,10 @@ internal final class MapboxHTTPAPI {
         let task = HttpRequestOperation(url: url, headers: headers, callback: {  (success, responseCode, data) -> Void in
             guard success, let data = data, let image = UIImage(data: data) else {
                 NSLog("Error downloading tile: \(responseCode)")
-                completion(nil)
+                completion(nil, FetchError(code: responseCode))
                 return
             }
-            completion(image)
+            completion(image, nil)
         }, session: URLSession.shared)
 
         MapboxHTTPAPI.operationQueue.addOperations([task], waitUntilFinished: false)


### PR DESCRIPTION
Usually, API returns error information when such has occurred. The benefit is that client app may be able to display a popup or whatever for the user to display why it isn't working or just save it to app logs. It is also very useful in #41, where we need to know about error 404, which is not reported from the network layer atm.