### PR TITLE
Handle cases when terrain elevation imagery and terrain imagery don't have the same zoom level

### DIFF
--- a/Examples/Base.lproj/Main.storyboard
+++ b/Examples/Base.lproj/Main.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="3jn-yz-y0n">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.3.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="3jn-yz-y0n">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.1"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -49,7 +48,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Applying hightmaps" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="iFJ-vJ-udS">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Applying heightmaps" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="iFJ-vJ-udS">
                                                     <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -472,10 +471,10 @@
                                 </userDefinedRuntimeAttributes>
                             </visualEffectView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Move iPhone" translatesAutoresizingMaskIntoConstraints="NO" id="Jhx-jZ-QaO">
-                                <rect key="frame" x="150" y="273.5" width="74" height="120"/>
+                                <rect key="frame" x="150.5" y="273.5" width="74" height="120"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ImG-VX-8sM">
-                                <rect key="frame" x="163" y="603" width="48" height="48"/>
+                                <rect key="frame" x="163.5" y="603" width="48" height="48"/>
                                 <state key="normal" image="Place"/>
                                 <connections>
                                     <action selector="place:" destination="LGO-U1-K7T" eventType="touchUpInside" id="z1M-eJ-1xV"/>

--- a/MapboxSceneKit.xcodeproj/project.pbxproj
+++ b/MapboxSceneKit.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		81A4372A20A2444B00F42A53 /* HTTPRequestOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A4372920A2444B00F42A53 /* HTTPRequestOperation.swift */; };
 		81CCF68720AA99CD00194B22 /* CGExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CCF68620AA99CD00194B22 /* CGExtensions.swift */; };
 		F44BB60520C75CBF00CE41C6 /* DemoExtrusionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F44BB60420C75CBF00CE41C6 /* DemoExtrusionViewController.m */; };
+		F450361321403C84000A040A /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F450361221403C84000A040A /* UIImage+Extensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -91,6 +92,7 @@
 		F44BB60220C75CBF00CE41C6 /* Examples-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Examples-Bridging-Header.h"; sourceTree = "<group>"; };
 		F44BB60320C75CBF00CE41C6 /* DemoExtrusionViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DemoExtrusionViewController.h; sourceTree = "<group>"; };
 		F44BB60420C75CBF00CE41C6 /* DemoExtrusionViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DemoExtrusionViewController.m; sourceTree = "<group>"; };
+		F450361221403C84000A040A /* UIImage+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -150,6 +152,7 @@
 			children = (
 				81CCF68620AA99CD00194B22 /* CGExtensions.swift */,
 				81A4372020A241E200F42A53 /* SCNExtensions.swift */,
+				F450361221403C84000A040A /* UIImage+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -375,6 +378,7 @@
 				81A4372A20A2444B00F42A53 /* HTTPRequestOperation.swift in Sources */,
 				81A4372520A243E100F42A53 /* AsyncOperation.swift in Sources */,
 				81A4372320A243B200F42A53 /* MapboxHTTPAPI.swift in Sources */,
+				F450361321403C84000A040A /* UIImage+Extensions.swift in Sources */,
 				814F3BD520ADF1B40006DDFD /* MapboxImageAPI.swift in Sources */,
 				81CCF68720AA99CD00194B22 /* CGExtensions.swift in Sources */,
 			);

--- a/MapboxSceneKit/Extensions/UIImage+Extensions.swift
+++ b/MapboxSceneKit/Extensions/UIImage+Extensions.swift
@@ -1,0 +1,30 @@
+//
+//  UIImage+Extensions.swift
+//  MapboxSceneKit
+//
+//  Created by Avi Cieplinski on 9/5/18.
+//  Copyright © 2018 MapBox. All rights reserved.
+//
+
+import UIKit
+
+extension UIImage {
+    func scaleImage(scaleFactor: CGFloat) -> UIImage {
+        let width = size.width * scaleFactor
+        let height = size.height * scaleFactor
+        let bitsPerComponent = cgImage!.bitsPerComponent
+        let bytesPerRow = scaleFactor * CGFloat(cgImage!.bytesPerRow)
+        let colorSpace = cgImage!.colorSpace
+        let bitmapInfo = CGImageAlphaInfo.noneSkipLast
+
+        let context = CGContext(data: nil, width: Int(width), height: Int(height), bitsPerComponent: bitsPerComponent, bytesPerRow: Int(bytesPerRow), space: colorSpace!, bitmapInfo: bitmapInfo.rawValue)
+
+        context?.interpolationQuality = .high
+
+        context?.draw(cgImage!, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        let scaledImage = context!.makeImage().flatMap { UIImage(cgImage: $0) }
+
+        return scaledImage!
+    }
+}

--- a/MapboxSceneKit/MapboxImageAPI.swift
+++ b/MapboxSceneKit/MapboxImageAPI.swift
@@ -129,7 +129,7 @@ public final class MapboxImageAPI: NSObject {
                         }
                         guard let image = image else {
                             hadFailure = true
-                            NSLog("Couldn't get image for tile {\(zoom),\(x),\(y)}")
+                            NSLog("Couldn't get image for tile {\(tileset)\(zoom),\(x),\(y)}")
                             return
                         }
 
@@ -211,7 +211,7 @@ public final class MapboxImageAPI: NSObject {
                         }
                         guard let image = image else {
                             hadFailure = true
-                            NSLog("Couldn't get image for tile {\(zoom),\(x),\(y)}")
+                            NSLog("Couldn't get image for tile {\(style)\(zoom),\(x),\(y)}")
                             return
                         }
 


### PR DESCRIPTION
Handle cases when terrain elevation imagery is not available at the same zoom level as terrain imagery. Scale the resulting elevation image to the proper size for generating the texture heightmap and for looking up height values at a given location.

This includes backing off the zoom level when there is no imagery available and then scaling the resulting bitmap image that is used for height lookup.