### PR TITLE
Provide access token

### DIFF
--- a/Examples/DemoPlacementViewController.swift
+++ b/Examples/DemoPlacementViewController.swift
@@ -112,7 +112,7 @@ class DemoPlacementViewController: UIViewController {
             locations.append(CLLocation(latitude: latlon.0, longitude: latlon.1))
         }
         
-        let lineA = terrainNode.addPolyline(coordinates: locations, radius: 20, color: .red)
+        terrainNode.addPolyline(coordinates: locations, radius: 20, color: .red)
         
         let lineB = terrainNode.addPolyline(coordinates: locations, startRadius: 30, endRadius: 80, startColor: .red, endColor: .yellow)
         lineB.position.y += 200

--- a/MapboxSceneKit/MapboxImageAPI.swift
+++ b/MapboxSceneKit/MapboxImageAPI.swift
@@ -52,28 +52,32 @@ public final class MapboxImageAPI: NSObject {
     private let httpAPI: MapboxHTTPAPI
     private var eventsManager: MMEEventsManager = MMEEventsManager.shared()
 
-    @objc
-    public override init() {
-        var mapboxAccessToken: String? = nil
+    @objc convenience public override init() {
+        var mapboxAccessToken = ""
         if let path = Bundle.main.path(forResource: "Info", ofType: "plist"),
             let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject],
             let token = dict["MGLMapboxAccessToken"] as? String {
             mapboxAccessToken = token
+        } else {
+            assert(false, "`accessToken` must be set in the Info.plist as `MGLMapboxAccessToken` or the `Route` passed into the `RouteController` must have the `accessToken` property set.")
         }
 
-        if let mapboxAccessToken = mapboxAccessToken {
+        self.init(mapboxAccessToken: mapboxAccessToken)
+    }
+    
+    @objc public init(mapboxAccessToken: String) {
+        if mapboxAccessToken.isEmpty {
+            assert(false, "MapBox AccessToken is missing or is empty, the models will not be working properly.")
+        } else {
             eventsManager.isMetricsEnabledInSimulator = true
             eventsManager.isMetricsEnabledForInUsePermissions = false
             eventsManager.initialize(withAccessToken: mapboxAccessToken, userAgentBase: "mapbox-scenekit-ios", hostSDKVersion: String(describing: Bundle(for: MapboxImageAPI.self).object(forInfoDictionaryKey: "CFBundleShortVersionString")!))
             eventsManager.disableLocationMetrics()
             eventsManager.sendTurnstileEvent()
-
-            httpAPI = MapboxHTTPAPI(accessToken: mapboxAccessToken)
-        } else {
-            assert(false, "`accessToken` must be set in the Info.plist as `MGLMapboxAccessToken` or the `Route` passed into the `RouteController` must have the `accessToken` property set.")
-            httpAPI = MapboxHTTPAPI(accessToken: "")
         }
-
+        
+        httpAPI = MapboxHTTPAPI(accessToken: mapboxAccessToken)
+        
         super.init()
     }
 

--- a/MapboxSceneKit/TerrainNode.swift
+++ b/MapboxSceneKit/TerrainNode.swift
@@ -33,7 +33,7 @@ open class TerrainNode: SCNNode {
     fileprivate var metersPerX: Double = 0
     fileprivate var metersPerY: Double = 0
     fileprivate var terrainHeights = [[Double]]()
-    private let api = MapboxImageAPI()
+    private let api: MapboxImageAPI
 
     fileprivate var pendingFetches = [UUID]()
     private static let queue = DispatchQueue(label: "com.mapbox.scenekit.processing", attributes: [.concurrent])
@@ -41,13 +41,22 @@ open class TerrainNode: SCNNode {
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    @objc convenience public init(minLat: CLLocationDegrees, maxLat: CLLocationDegrees, minLon: CLLocationDegrees, maxLon: CLLocationDegrees) {
+        self.init(api: MapboxImageAPI(), minLat: minLat, maxLat: maxLat, minLon: minLon, maxLon: maxLon)
+    }
+    
+    @objc convenience public init(mapboxAccessToken: String, minLat: CLLocationDegrees, maxLat: CLLocationDegrees, minLon: CLLocationDegrees, maxLon: CLLocationDegrees) {
+        self.init(api: MapboxImageAPI(mapboxAccessToken: mapboxAccessToken), minLat: minLat, maxLat: maxLat, minLon: minLon, maxLon: maxLon)
+    }
 
-    @objc public init(minLat: CLLocationDegrees, maxLat: CLLocationDegrees, minLon: CLLocationDegrees, maxLon: CLLocationDegrees) {
+    private init(api: MapboxImageAPI, minLat: CLLocationDegrees, maxLat: CLLocationDegrees, minLon: CLLocationDegrees, maxLon: CLLocationDegrees) {
         assert(minLat >= -90.0 && minLat <= 90.0 && maxLat >= -90.0 && maxLat <= 90.0, "lats must be between -90.0 and 90.0")
         assert(minLon >= -180.0 && minLon <= 180.0 && maxLon >= -180.0 && maxLon <= 180.0, "lons must be between -180.0 and 180.0")
         assert(minLat < maxLat, "minLat must be less than maxLat")
         assert(minLon < maxLon, "minLon must be less than maxLon")
 
+        self.api = api
         latBounds = (minLat, maxLat)
         lonBounds = (minLon, maxLon)
         metersPerLat = 1 / Math.metersToDegreesForLat(at: maxLon)


### PR DESCRIPTION
Saving the access token in plist is a threat when someone wants to reverse engineer the app. Plist is very easily readable. To make it more difficult for potential hacker even having it in code is harder to find and read, especially if it's obfuscated.
This pull request leaves the old, simple inits as they were but adds another way for people who need to keep their data secure. They can keep the token in a way they prefer and provide it in code, eg after deobfuscating.