### PR TITLE
add .metal files to podspec source

### DIFF
--- a/MapboxSceneKit.podspec
+++ b/MapboxSceneKit.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
-  s.source_files = ["MapboxSceneKit/**/*.swift"]
+  s.source_files = ["MapboxSceneKit/**/*.{swift,metal}"]
 
   # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 


### PR DESCRIPTION
Addresses #52 

Metal files were omitted from the podspec's source, so a MTLLibrary was never created for bundles installed via cocoapods.