### PR TITLE
use linear color space in polyline shader

### DIFF
--- a/MapboxSceneKit/Routes/Shaders/unlit-line.metal
+++ b/MapboxSceneKit/Routes/Shaders/unlit-line.metal
@@ -91,6 +91,13 @@ vertex Vertex lineVert(VertexInput in [[ stage_in ]],
     return vert;
 }
 
+static float srgbToLinear(float c) {
+    if (c <= 0.04045)
+        return c / 12.92;
+    else
+        return powr((c + 0.055) / 1.055, 2.4);
+}
+
 struct FragmentOutput {
     // color attachment 0
     half4 color [[color(0)]];
@@ -109,6 +116,9 @@ fragment FragmentOutput lineFrag(Vertex in [[stage_in]]) {
     }
     //premultiply alpha
     output.color = lineAlpha * in.color;
+    output.color.r = srgbToLinear(output.color.r);
+    output.color.g = srgbToLinear(output.color.g);
+    output.color.b = srgbToLinear(output.color.b);
     
     if( in.zOffset > 0 ) {
         //offset the z value of the fragment by the line width to create a cylinder effect when intersecting with other geometry.

--- a/MapboxSceneKit/Routes/Shaders/unlit-line.metal
+++ b/MapboxSceneKit/Routes/Shaders/unlit-line.metal
@@ -34,6 +34,12 @@ struct Vertex {
     float zOffset;
 };
 
+/*
+ Linear color space conversion happens automatically for sRGBA textures,
+ but not for vertex colors. This conversion method is copied from section
+ 7.7.7 of the Metal Language Spec:
+( https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf )
+ */
 static float srgbToLinear(float c) {
     if (c <= 0.04045)
         return c / 12.92;


### PR DESCRIPTION
Addresses #54 

The unlit-line shader incorrectly output in gamma color space. This fix updates the output color space to linear with the formula outlined in https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf (7.7.7).