### PR TITLE
Avoid terrain intersection when using addPolyline()

### DIFF
--- a/MapboxSceneKit/Extensions/SCNExtensions.swift
+++ b/MapboxSceneKit/Extensions/SCNExtensions.swift
@@ -156,4 +156,10 @@ internal func +(lhs: SCNVector4, rhs: SCNVector4) -> SCNVector4 {
     return SCNVector4(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z, lhs.w + rhs.w)
 }
 
+internal extension SCNVector3 {
+    func length() -> Float {
+        return sqrtf(x * x + y * y + z * z)
+    }
+}
+
 

--- a/MapboxSceneKit/Routes/BezierSpline3D.swift
+++ b/MapboxSceneKit/Routes/BezierSpline3D.swift
@@ -24,7 +24,8 @@ internal class BezierSpline3D {
             self.curvePoints = [curvePoints[0], curvePoints[0], curvePoints[0], curvePoints[0]]
         case 2:
             //straight line, add extra handles at the end points.
-            self.curvePoints = [curvePoints[0], curvePoints[0], curvePoints[1], curvePoints[1]]
+            self.curvePoints = [curvePoints[0], curvePoints[0],
+                                curvePoints[1], curvePoints[1]]
         case 3:
             //add a single handle at the end
             self.curvePoints = [curvePoints[0], curvePoints[0],

--- a/MapboxSceneKit/Routes/PolylineCylinder.swift
+++ b/MapboxSceneKit/Routes/PolylineCylinder.swift
@@ -18,7 +18,7 @@ internal class PolylineCylinder: PolylineRenderer {
 
         self.sampleCount = sampleCount
         var positions = [SCNVector3]()
-        for index in 1..<sampleCount {
+        for index in 0..<sampleCount {
             positions.append(polyline.getPositon(atProgress: progressAtSample(index)))
         }
         let radius = polyline.getRadius(atProgress: 0)
@@ -49,7 +49,7 @@ internal class PolylineCylinder: PolylineRenderer {
     }
 
     private func progressAtSample(_ sample: Int) -> CGFloat {
-        return (CGFloat(sample) / CGFloat(sampleCount))
+        return (CGFloat(sample) / CGFloat(sampleCount - 1))
     }
 
     private func sphere( position: SCNVector3, radius: CGFloat, color: UIColor) -> SCNNode {

--- a/MapboxSceneKit/Routes/PolylineShader.swift
+++ b/MapboxSceneKit/Routes/PolylineShader.swift
@@ -42,7 +42,7 @@ internal class PolylineShader: PolylineRenderer {
     }
 
     private func progressAtSample(_ sample: Int) -> CGFloat {
-        return (CGFloat(sample) / CGFloat(sampleCount))
+        return (CGFloat(sample) / CGFloat(sampleCount - 1))
     }
 
     private func generateMaterial() -> SCNMaterial {

--- a/MapboxSceneKit/Routes/TerrainNodeExtension+Routes.swift
+++ b/MapboxSceneKit/Routes/TerrainNodeExtension+Routes.swift
@@ -111,10 +111,10 @@ extension TerrainNode {
             let maxSampleRate = lengthInMeters / self.metersPerX
             //resample at a 1/5 of the maximum terrain resolution
             let sampleRate = floor(maxSampleRate * 0.2)
-            print(sampleRate)
+
             //sample rates above 1 might have intersecting terrain, re-sample these segments.
             //below 1 means there's no difference in the height data between the two points, so no need to re-sample
-            for sampleIndex in 1..<Int(sampleRate) {
+            for sampleIndex in 0..<Int(sampleRate) where sampleIndex > 0{
                 //define a spline for the segment
                 positionBezier = BezierSpline3D(curvePoints: [fromPostion, toPositon])
                 

--- a/MapboxSceneKit/Routes/TerrainNodeExtension+Routes.swift
+++ b/MapboxSceneKit/Routes/TerrainNodeExtension+Routes.swift
@@ -81,6 +81,53 @@ extension TerrainNode {
             let position = self.positionForLocation(coord)
             scenePositions.append(position)
         }
+        
+        
+        scenePositions = subdivideAndSnapToTerrain(positions: scenePositions)
         return scenePositions
+    }
+    
+    /// Resamples the provided route based on zoom level to avoid polylines that intersect, or float above terrain.
+    ///
+    /// - Parameter positions: the positions to be re-sampled
+    /// - Returns: the final route, snapped to the terrainNode's surface
+    fileprivate func subdivideAndSnapToTerrain(positions: [SCNVector3]) -> [SCNVector3] {
+        
+        //get the total meters traveled by the line
+        var lengthInMeters: Double = 0.0
+        for index in 1..<positions.count {
+            lengthInMeters += Double((positions[index] - positions[index - 1]).length())
+        }
+        
+        //resample the line based on the terrainNode's of pixels per meter
+        let maxSampleRate = lengthInMeters / self.metersPerX
+        
+        //sample at 1/10th the maximum terrain resolution
+        let sampleRate = ceil(maxSampleRate * 0.1)
+        
+        //don't sub-sample the line
+        if( sampleRate < Double(positions.count) ) {
+            return positions
+        }
+        
+        //create a new spline to interpolate along given positions
+        let positionBezier = BezierSpline3D(curvePoints: positions)
+        var newPositions =  [SCNVector3]()
+        for index in 0...Int(sampleRate) {
+            let currentProgress = CGFloat(CGFloat(index)/CGFloat(sampleRate))
+            
+            //get position at index/subdivisionfactor progress
+            let samplePosition: SCNVector3 = positionBezier.evaluate(progress: currentProgress)
+            
+            //get the height at this position
+            let newPosition  = SCNVector3(samplePosition.x,
+                                          Float(self.heightForLocalPosition(samplePosition)),
+                                          samplePosition.z)
+            
+            //add this to the newpositions list
+            newPositions.append(newPosition)
+        }
+        
+        return newPositions
     }
 }

--- a/MapboxSceneKit/TerrainNode.swift
+++ b/MapboxSceneKit/TerrainNode.swift
@@ -106,15 +106,15 @@ open class TerrainNode: SCNNode {
     /// - Parameter location: Location in the real world.
     /// - Returns: Vector position should be converted from the terrain local space to the world space (or another node's corrdinate space, as needed).
     @objc public func positionForLocation(_ location: CLLocation) -> SCNVector3 {
-        let xz = coordinates(location: location)
-        let z = heightForLocalPosition(SCNVector3(xz.x, 0.0, xz.z))
-        return SCNVector3(xz.x, Float(max(z, location.altitude)), xz.z)
+        let coords = coordinates(location: location)
+        let groundLevel = heightForLocalPosition(SCNVector3(coords.x, 0.0, coords.z))
+        return SCNVector3(coords.x, Float(max(groundLevel, location.altitude)), coords.z)
     }
     
     @objc public func heightForLocalPosition(_ position: SCNVector3) -> Double {
-        let xz = ( x: position.x, z: position.z)
-        if let z = TerrainNode.height(heights: terrainHeights, x: xz.x, z: xz.z, metersPerX: metersPerX, metersPerY: metersPerY) {
-            return z
+        let coords = ( x: position.x, z: position.z)
+        if let groundLevel = TerrainNode.height(heights: terrainHeights, x: coords.x, z: coords.z, metersPerX: metersPerX, metersPerY: metersPerY) {
+            return groundLevel
         } else {
             return 0.0
         }

--- a/MapboxSceneKit/TerrainNode.swift
+++ b/MapboxSceneKit/TerrainNode.swift
@@ -107,10 +107,16 @@ open class TerrainNode: SCNNode {
     /// - Returns: Vector position should be converted from the terrain local space to the world space (or another node's corrdinate space, as needed).
     @objc public func positionForLocation(_ location: CLLocation) -> SCNVector3 {
         let xz = coordinates(location: location)
+        let z = heightForLocalPosition(SCNVector3(xz.x, 0.0, xz.z))
+        return SCNVector3(xz.x, Float(max(z, location.altitude)), xz.z)
+    }
+    
+    @objc public func heightForLocalPosition(_ position: SCNVector3) -> Double {
+        let xz = ( x: position.x, z: position.z)
         if let z = TerrainNode.height(heights: terrainHeights, x: xz.x, z: xz.z, metersPerX: metersPerX, metersPerY: metersPerY) {
-            return SCNVector3(xz.x, Float(max(z, location.altitude)), xz.z)
+            return z
         } else {
-            return SCNVector3(xz.x, 0.0, xz.z)
+            return 0.0
         }
     }
     

--- a/MapboxSceneKit/TerrainNode.swift
+++ b/MapboxSceneKit/TerrainNode.swift
@@ -30,8 +30,8 @@ open class TerrainNode: SCNNode {
     fileprivate var terrainSize: CGSize = CGSize.zero
     fileprivate let metersPerLat: Double
     fileprivate let metersPerLon: Double
-    fileprivate var metersPerX: Double = 0
-    fileprivate var metersPerY: Double = 0
+    internal var metersPerX: Double = 0
+    internal var metersPerY: Double = 0
     fileprivate var terrainHeights = [[Double]]()
     private let api = MapboxImageAPI()
 


### PR DESCRIPTION
Previously, using addPolyline created terrain intersections and floating lines when drawn across terrain with dramatic elevation changes. Sample line with only start and end points defined (50.107331, -122.891896), (50.052916, -122.960512):
![img_0048](https://user-images.githubusercontent.com/9599047/46034295-252b2c00-c0b5-11e8-9ac0-aa11b962e256.PNG)

This change subdivides the route by a factor of the terrain's height-map resolution to fit segments along the geometry:
![img_0047](https://user-images.githubusercontent.com/9599047/46034293-24929580-c0b5-11e8-9f9a-e0cecf04f30a.PNG)


I've also made public a `heightForLocalPosition()` method that allows users to check the terrainNode's height at a given SCNVector3 location, rather than being limited to CLLocation or raycasting.


