### PR TITLE
TerrainNode refactor

### DIFF
--- a/Examples/DemoPlacementViewController.swift
+++ b/Examples/DemoPlacementViewController.swift
@@ -115,7 +115,7 @@ class DemoPlacementViewController: UIViewController {
             locations.append(CLLocation(latitude: latlon.0, longitude: latlon.1))
         }
         
-        let lineA = terrainNode.addPolyline(coordinates: locations, radius: 20, color: .red)
+        terrainNode.addPolyline(coordinates: locations, radius: 20, color: .red)
         
         let lineB = terrainNode.addPolyline(coordinates: locations, startRadius: 30, endRadius: 80, startColor: .red, endColor: .yellow)
         lineB.position.y += 200

--- a/Examples/DemoPlacementViewController.swift
+++ b/Examples/DemoPlacementViewController.swift
@@ -30,8 +30,11 @@ class DemoPlacementViewController: UIViewController {
         sceneView.showsStatistics = true
 
         //Set up initial terrain and materials
-        let terrainNode = TerrainNode(minLat: 50.044660402821592, maxLat: 50.120873988090956,
-                                      minLon: -122.99017089272466, maxLon: -122.86824490727534)
+        let southWest = CLLocationCoordinate2D(latitude: 50.044660402821592, longitude: -122.99017089272466)
+        let northEast = CLLocationCoordinate2D(latitude: 50.120873988090956, longitude: -122.86824490727534)
+//        let terrainNode = TerrainNode(minLat: 50.044660402821592, maxLat: 50.120873988090956,
+//                                      minLon: -122.99017089272466, maxLon: -122.86824490727534)
+        let terrainNode = TerrainNode(southWestCorner: southWest, northEastCorner: northEast)
         terrainNode.position = SCNVector3(0, 500, 0)
         terrainNode.geometry?.materials = defaultMaterials()
         scene.rootNode.addChildNode(terrainNode)

--- a/Examples/DemoPlacementViewController.swift
+++ b/Examples/DemoPlacementViewController.swift
@@ -30,8 +30,8 @@ class DemoPlacementViewController: UIViewController {
         sceneView.showsStatistics = true
 
         //Set up initial terrain and materials
-        let southWest = CLLocationCoordinate2D(latitude: 50.044660402821592, longitude: -122.99017089272466)
-        let northEast = CLLocationCoordinate2D(latitude: 50.120873988090956, longitude: -122.86824490727534)
+        let southWest = CLLocation(latitude: 50.044660402821592, longitude: -122.99017089272466)
+        let northEast = CLLocation(latitude: 50.120873988090956, longitude: -122.86824490727534)
 //        let terrainNode = TerrainNode(minLat: 50.044660402821592, maxLat: 50.120873988090956,
 //                                      minLon: -122.99017089272466, maxLon: -122.86824490727534)
         let terrainNode = TerrainNode(southWestCorner: southWest, northEastCorner: northEast)

--- a/Examples/DemoPlacementViewController.swift
+++ b/Examples/DemoPlacementViewController.swift
@@ -32,8 +32,6 @@ class DemoPlacementViewController: UIViewController {
         //Set up initial terrain and materials
         let southWest = CLLocation(latitude: 50.044660402821592, longitude: -122.99017089272466)
         let northEast = CLLocation(latitude: 50.120873988090956, longitude: -122.86824490727534)
-//        let terrainNode = TerrainNode(minLat: 50.044660402821592, maxLat: 50.120873988090956,
-//                                      minLon: -122.99017089272466, maxLon: -122.86824490727534)
         let terrainNode = TerrainNode(southWestCorner: southWest, northEastCorner: northEast)
         terrainNode.position = SCNVector3(0, 500, 0)
         terrainNode.geometry?.materials = defaultMaterials()

--- a/MapboxSceneKit.xcodeproj/project.pbxproj
+++ b/MapboxSceneKit.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		957C85EA2146FF92004C548E /* SCNProgramExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957C85E52146FF92004C548E /* SCNProgramExtensions.swift */; };
 		957C85EB2146FF92004C548E /* BezierSpline3D.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957C85E62146FF92004C548E /* BezierSpline3D.swift */; };
 		957C85EC2146FF92004C548E /* TerrainNodeExtension+Routes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957C85E72146FF92004C548E /* TerrainNodeExtension+Routes.swift */; };
+		9598A005215EB4E80086CF4E /* StaticConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9598A003215EB4460086CF4E /* StaticConstants.swift */; };
 		959F81622149DE9700A290DF /* PolylineRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 959F81612149DE9700A290DF /* PolylineRenderer.swift */; };
 		95CC6AA4214ADB05000CD0E6 /* SCNExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CC6AA3214ADB05000CD0E6 /* SCNExtensions.swift */; };
 		F44BB60520C75CBF00CE41C6 /* DemoExtrusionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F44BB60420C75CBF00CE41C6 /* DemoExtrusionViewController.m */; };
@@ -102,6 +103,7 @@
 		957C85E52146FF92004C548E /* SCNProgramExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SCNProgramExtensions.swift; sourceTree = "<group>"; };
 		957C85E62146FF92004C548E /* BezierSpline3D.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BezierSpline3D.swift; sourceTree = "<group>"; };
 		957C85E72146FF92004C548E /* TerrainNodeExtension+Routes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TerrainNodeExtension+Routes.swift"; sourceTree = "<group>"; };
+		9598A003215EB4460086CF4E /* StaticConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticConstants.swift; sourceTree = "<group>"; };
 		959F81612149DE9700A290DF /* PolylineRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolylineRenderer.swift; sourceTree = "<group>"; };
 		95CC6AA3214ADB05000CD0E6 /* SCNExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SCNExtensions.swift; sourceTree = "<group>"; };
 		F44BB60220C75CBF00CE41C6 /* Examples-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Examples-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -196,6 +198,7 @@
 				81A436BF20A1F68500F42A53 /* MapboxSceneKit.h */,
 				81A436C720A1F6BC00F42A53 /* TerrainNode.swift */,
 				814F3BD420ADF1B40006DDFD /* MapboxImageAPI.swift */,
+				9598A003215EB4460086CF4E /* StaticConstants.swift */,
 				81A4371620A1FAB700F42A53 /* Math.swift */,
 				957C85E12146FF92004C548E /* Routes */,
 				814F3BD820AE02E60006DDFD /* Extensions */,
@@ -421,6 +424,7 @@
 				81A4372320A243B200F42A53 /* MapboxHTTPAPI.swift in Sources */,
 				957C85E82146FF92004C548E /* PolylineShader.swift in Sources */,
 				954A248221484F330050025E /* PolylineNode.swift in Sources */,
+				9598A005215EB4E80086CF4E /* StaticConstants.swift in Sources */,
 				957C85EA2146FF92004C548E /* SCNProgramExtensions.swift in Sources */,
 				814F3BD520ADF1B40006DDFD /* MapboxImageAPI.swift in Sources */,
 				957C85EB2146FF92004C548E /* BezierSpline3D.swift in Sources */,

--- a/MapboxSceneKit/MapboxImageAPI.swift
+++ b/MapboxSceneKit/MapboxImageAPI.swift
@@ -46,6 +46,9 @@ public final class MapboxImageAPI: NSObject {
     fileprivate static let tileSize = CGSize(width: 256, height: 256)
     fileprivate static let styleSize = CGSize(width: 256, height: 256)
     fileprivate var pendingFetches = [UUID: [UUID]]()
+    public static var tileSizeWidth: Double {
+        get { return Double(MapboxImageAPI.tileSize.width) }
+    }
 
     private static let queue = DispatchQueue(label: "com.mapbox.scenekit.processing", attributes: [.concurrent])
 

--- a/MapboxSceneKit/MapboxImageAPI.swift
+++ b/MapboxSceneKit/MapboxImageAPI.swift
@@ -100,10 +100,14 @@ public final class MapboxImageAPI: NSObject {
      Returns a UUID representing the task managing the fetching and stitching together of the tile images. Used for cancellation if needed.
      **/
     @objc
-    public func image(forTileset tileset: String, zoomLevel zoom: Int, minLat: CLLocationDegrees, maxLat: CLLocationDegrees, minLon: CLLocationDegrees, maxLon: CLLocationDegrees, format: String, progress: TileLoadProgressCallback? = nil, completion: @escaping TileLoadCompletion) -> UUID {
-        let latBounds = (minLat, maxLat)
-        let lonBounds = (minLon, maxLon)
-        let bounding = MapboxImageAPI.tiles(zoom: zoom, latBounds: latBounds, lonBounds: lonBounds, tileSize: MapboxImageAPI.tileSize)
+    public func image(forTileset tileset: String,
+                      zoomLevel zoom: Int,
+                      southWestCorner: CLLocation,
+                      northEastCorner: CLLocation,
+                      format: String, progress: TileLoadProgressCallback? = nil,
+                      completion: @escaping TileLoadCompletion) -> UUID {
+
+        let bounding = MapboxImageAPI.tiles(zoom: zoom, southWestCorner: southWestCorner, northEastCorner: northEastCorner, tileSize: MapboxImageAPI.tileSize)
         let imageBuilder = ImageBuilder(xs: bounding.xs.count, ys: bounding.ys.count, tileSize: MapboxImageAPI.tileSize, insets: bounding.insets)
 
         let group = DispatchGroup()
@@ -180,12 +184,10 @@ public final class MapboxImageAPI: NSObject {
      Returns a UUID representing the task managing the fetching and stitching together of the tile images. Used for cancellation if needed.
      **/
     @objc
-    public func image(forStyle style: String, zoomLevel zoom: Int, minLat: CLLocationDegrees, maxLat: CLLocationDegrees, minLon: CLLocationDegrees, maxLon: CLLocationDegrees, progress: TileLoadProgressCallback? = nil, completion: @escaping TileLoadCompletion) -> UUID {
+    public func image(forStyle style: String, zoomLevel zoom: Int, southWestCorner: CLLocation, northEastCorner: CLLocation, progress: TileLoadProgressCallback? = nil, completion: @escaping TileLoadCompletion) -> UUID {
         //Note: this API endpoint returns at 2x the normal tile size (512 covers a bounding box calculated for 256), but relies on the bounding size of the normal size (256)
-        let latBounds = (minLat, maxLat)
-        let lonBounds = (minLon, maxLon)
         let returnedSize = MapboxImageAPI.styleSize * CGFloat(2.0)
-        let bounding = MapboxImageAPI.tiles(zoom: zoom, latBounds: latBounds, lonBounds: lonBounds, tileSize: MapboxImageAPI.styleSize)
+        let bounding = MapboxImageAPI.tiles(zoom: zoom, southWestCorner: southWestCorner, northEastCorner: northEastCorner, tileSize: MapboxImageAPI.styleSize)
         let imageBuilder = ImageBuilder(xs: bounding.xs.count, ys: bounding.ys.count, tileSize: returnedSize, insets: bounding.insets * 2)
 
         let group = DispatchGroup()
@@ -250,27 +252,33 @@ public final class MapboxImageAPI: NSObject {
 
     //MARK: - Helpers
 
-    internal static func tiles(zoom: Int, latBounds: (CLLocationDegrees, CLLocationDegrees), lonBounds: (CLLocationDegrees, CLLocationDegrees), tileSize: CGSize) -> (xs: [Int], ys: [Int], insets: UIEdgeInsets) {
+    internal static func tiles(zoom: Int, southWestCorner: CLLocation, northEastCorner: CLLocation, tileSize: CGSize) -> (xs: [Int], ys: [Int], insets: UIEdgeInsets) {
+        
+        let minLat = southWestCorner.coordinate.latitude
+        let maxLat = northEastCorner.coordinate.latitude
+        let minLon = southWestCorner.coordinate.longitude
+        let maxLon = northEastCorner.coordinate.longitude
+        
         var xs = [Int]()
         var ys = [Int]()
         var insets = UIEdgeInsets.zero
 
-        for lat in [latBounds.0, latBounds.1] {
-            for lon in [lonBounds.0, lonBounds.1] {
+        for lat in [minLat, maxLat] {
+            for lon in [minLon, maxLon] {
                 let tile = Math.latLng2tile(lat: lat, lon: lon, zoom: zoom, tileSize: tileSize)
                 xs.append(tile.xTile)
                 ys.append(tile.yTile)
 
-                if lat == latBounds.0 {
+                if lat == minLat {
                     insets = UIEdgeInsets(top: insets.top, left: insets.left, bottom: tileSize.height - CGFloat(tile.yPos), right: insets.right)
                 }
-                if lat == latBounds.1 {
+                if lat == maxLat {
                     insets = UIEdgeInsets(top: CGFloat(tile.yPos), left: insets.left, bottom: insets.bottom, right: insets.right)
                 }
-                if lon == lonBounds.0 {
+                if lon == minLon {
                     insets = UIEdgeInsets(top: insets.top, left: CGFloat(tile.xPos), bottom: insets.bottom, right: insets.right)
                 }
-                if lon == lonBounds.1 {
+                if lon == maxLon {
                     insets = UIEdgeInsets(top: insets.top, left: insets.left, bottom: insets.bottom, right: tileSize.width - CGFloat(tile.xPos))
                 }
             }

--- a/MapboxSceneKit/Math.swift
+++ b/MapboxSceneKit/Math.swift
@@ -15,6 +15,7 @@ internal class Math {
         let a = cos(2 * Math.degreesToRadians(longitude))
         let b = cos(4 * Math.degreesToRadians(longitude))
         let c = cos(6 * Math.degreesToRadians(longitude))
+        
         return 1.0 / fabs(111132.95255 - 559.84957 * a + 1.17514 * b - 0.00230 * c)
     }
 
@@ -22,6 +23,7 @@ internal class Math {
         let a = cos(Math.degreesToRadians(latitude))
         let b = cos(3 * Math.degreesToRadians(latitude))
         let c = cos(5 * Math.degreesToRadians(latitude))
+        
         return 1.0 / fabs(111412.87733 * a - 93.50412 * b + 0.11774 * c)
     }
 
@@ -40,12 +42,27 @@ internal class Math {
         let lon = Double(x) / pow(2.0, Double(z)) * 360.0 - 180.0
         let n = Double.pi - 2.0 * Double.pi * Double(y) / pow(2.0, Double(z))
         let lat = Math.radiansToDegrees(atan(0.5 * (exp(n) - exp(-n))))
+        
         return (lat, lon)
     }
 
     static func tile2BoundingBox(x: Int, y: Int, z: Int) -> (latBounds: (CLLocationDegrees, CLLocationDegrees), lonBounds: (CLLocationDegrees, CLLocationDegrees)) {
         let topLeft = tile2LatLng(x: x, y: y, z: z)
         let bottomRight = tile2LatLng(x: x + 1, y: y + 1, z: z)
+        
         return ((bottomRight.lat, topLeft.lat), (topLeft.lon, bottomRight.lon))
+    }
+    
+    static func zoomLevelForBounds(southWestCorner: CLLocation, northEastCorner: CLLocation) -> Int {
+        let distance = northEastCorner.distance(from: southWestCorner) / 1000.0 //use kilometers
+        let imageSize = Double(Constants.maxTextureImageSize)
+        let latitudeAdjustment = cos(.pi * northEastCorner.coordinate.latitude / 180)
+        let arg = Constants.earthDiameterInKilometers
+                    * imageSize
+                    * latitudeAdjustment
+                    / (distance * MapboxImageAPI.tileSizeWidth)
+        let zoom = Int(round(log(arg)/log(2)))
+        
+        return zoom
     }
 }

--- a/MapboxSceneKit/Math.swift
+++ b/MapboxSceneKit/Math.swift
@@ -11,7 +11,7 @@ internal class Math {
         return radians * 180.0 / Double.pi
     }
 
-    static func metersToDegreesForLat(at longitude: CLLocationDegrees) -> CLLocationDistance {
+    static func metersToDegreesForLat(atLongitude longitude: CLLocationDegrees) -> CLLocationDistance {
         let a = cos(2 * Math.degreesToRadians(longitude))
         let b = cos(4 * Math.degreesToRadians(longitude))
         let c = cos(6 * Math.degreesToRadians(longitude))
@@ -19,7 +19,7 @@ internal class Math {
         return 1.0 / fabs(111132.95255 - 559.84957 * a + 1.17514 * b - 0.00230 * c)
     }
 
-    static func metersToDegreesForLon(at latitude: CLLocationDegrees) -> CLLocationDistance {
+    static func metersToDegreesForLon(atLatitude latitude: CLLocationDegrees) -> CLLocationDistance {
         let a = cos(Math.degreesToRadians(latitude))
         let b = cos(3 * Math.degreesToRadians(latitude))
         let c = cos(5 * Math.degreesToRadians(latitude))

--- a/MapboxSceneKit/Routes/TerrainNodeExtension+Routes.swift
+++ b/MapboxSceneKit/Routes/TerrainNodeExtension+Routes.swift
@@ -109,7 +109,7 @@ extension TerrainNode {
              More samples would read the same pixel multiple times per line, creating jagged steps.
              */
             let lengthInMeters = Double((toPositon - fromPostion).length())
-            let maxSamplesInSegment = lengthInMeters / self.metersPerX
+            let maxSamplesInSegment = lengthInMeters / self.metersPerPixelX
             
             //resample at a 1/5 of the maximum terrain resolution, to save on performance.
             let samplesInSegment = floor(maxSamplesInSegment * 0.2)

--- a/MapboxSceneKit/StaticConstants.swift
+++ b/MapboxSceneKit/StaticConstants.swift
@@ -5,7 +5,7 @@
 //  Created by Jim Martin on 9/28/18.
 //  Copyright © 2018 MapBox. All rights reserved.
 //
-
+import CoreLocation
 import Foundation
 
 struct Constants {

--- a/MapboxSceneKit/StaticConstants.swift
+++ b/MapboxSceneKit/StaticConstants.swift
@@ -15,5 +15,8 @@ struct Constants {
     /// Is the largest supported texture size by the SDK, style images are drawn at 2x this value, so any higher number would result in crashes.
     static let maxTextureImageSize: Int = 2048
     
+    /// The maximum number of terrain generation attempts to make before terrainNode generation is cancelled, returning an error.
+    static let maxRequestAttempts: Int = 3
+    
     static let earthDiameterInKilometers = 40075.16
 }

--- a/MapboxSceneKit/StaticConstants.swift
+++ b/MapboxSceneKit/StaticConstants.swift
@@ -9,7 +9,11 @@ import CoreLocation
 import Foundation
 
 struct Constants {
-    static let maxTextureImageSize: Int = 2048 // set a max texture size in order to dynamically calculate the highest zoom level for a given lat/lon bounding rect. Need to balance download speed and detail, so set to 1MB for now
+    /// Terrain.rgb isn't available in all areas beyond this value, higher zoom levels are oversampled.
+    static let maxTerrainRGBZoomLevel: Int = 12
+    
+    /// Is the largest supported texture size by the SDK, style images are drawn at 2x this value, so any higher number would result in crashes.
+    static let maxTextureImageSize: Int = 2048
     
     static let earthDiameterInKilometers = 40075.16
 }

--- a/MapboxSceneKit/StaticConstants.swift
+++ b/MapboxSceneKit/StaticConstants.swift
@@ -1,0 +1,15 @@
+//
+//  StaticConstants.swift
+//  Examples
+//
+//  Created by Jim Martin on 9/28/18.
+//  Copyright © 2018 MapBox. All rights reserved.
+//
+
+import Foundation
+
+struct Constants {
+    static let maxTextureImageSize: Int = 2048 // set a max texture size in order to dynamically calculate the highest zoom level for a given lat/lon bounding rect. Need to balance download speed and detail, so set to 1MB for now
+    
+    static let earthDiameterInKilometers = 40075.16
+}

--- a/MapboxSceneKit/TerrainNode.swift
+++ b/MapboxSceneKit/TerrainNode.swift
@@ -103,6 +103,10 @@ open class TerrainNode: SCNNode {
         return SCNVector3(coords.x, Float(max(groundLevel, location.altitude)), coords.z)
     }
     
+    /// Returns the height at ground level of the terrain node at a given local position.
+    ///
+    /// - Parameter position: postion for the height lookup in the terrainNode's local space.
+    /// - Returns: height value at the input position. Apply this to the Y component of the input position to place it on the TerrainNode's surface.
     @objc public func heightForLocalPosition(_ position: SCNVector3) -> Double {
         let coords = (x: position.x, z: position.z)
         

--- a/MapboxSceneKit/TerrainNode.swift
+++ b/MapboxSceneKit/TerrainNode.swift
@@ -54,6 +54,11 @@ open class TerrainNode: SCNNode {
     
     @objc public init(southWestCorner: CLLocation, northEastCorner: CLLocation) {
         
+        assert(CLLocationCoordinate2DIsValid(southWestCorner.coordinate), "TerrainNode southWestCorner coordinates are invalid.")
+        assert(CLLocationCoordinate2DIsValid(northEastCorner.coordinate), "TerrainNode northEastCorner coordinates are invalid.")
+        assert(southWestCorner.coordinate.latitude < northEastCorner.coordinate.latitude, "southWestCorner must be South of northEastCorner")
+        assert(southWestCorner.coordinate.longitude < northEastCorner.coordinate.longitude, "southWestCorner must be West of northEastCorner")
+        
         self.southWestCorner = southWestCorner
         self.northEastCorner = northEastCorner
         self.styleZoomLevel = Math.zoomLevelForBounds(southWestCorner: southWestCorner,

--- a/MapboxSceneKit/TerrainNode.swift
+++ b/MapboxSceneKit/TerrainNode.swift
@@ -60,8 +60,8 @@ open class TerrainNode: SCNNode {
                                                                northEastCorner: northEastCorner)
         self.terrainZoomLevel = min(styleZoomLevel, Constants.maxTerrainRGBZoomLevel)
         
-        self.metersPerLat = 1 / Math.metersToDegreesForLat(at: northEastCorner.coordinate.latitude)
-        self.metersPerLon = 1 / Math.metersToDegreesForLon(at: northEastCorner.coordinate.longitude)
+        self.metersPerLat = 1 / Math.metersToDegreesForLat(atLongitude: northEastCorner.coordinate.longitude)
+        self.metersPerLon = 1 / Math.metersToDegreesForLon(atLatitude: northEastCorner.coordinate.latitude)
 
         super.init()
         geometry = SCNBox(width: terrainSizeMeters.width,

--- a/MapboxSceneKit/TerrainNode.swift
+++ b/MapboxSceneKit/TerrainNode.swift
@@ -154,12 +154,8 @@ open class TerrainNode: SCNNode {
             [weak self] heightFetchError in
             guard let `self` = self else { return }
             guard let heightFetchError = heightFetchError else {
-                // if there is no fetch error, height data is available and we can fetch texture for this zoom level
+                // if there is no fetch error, height data is available
                 heightCompletion(nil)
-                self.fetchTerrainTexture(style, zoom: self.styleZoomLevel,
-                                         progress: textureProgress,
-                                         completion: textureCompletion)
-                
                 return
             }
             
@@ -182,6 +178,11 @@ open class TerrainNode: SCNNode {
                 textureCompletion(nil, heightFetchError)
             }
         }
+        
+        //fetch texture in parallel to heights
+        self.fetchTerrainTexture(style, zoom: self.styleZoomLevel,
+                                 progress: textureProgress,
+                                 completion: textureCompletion)
     }
     
     /// DEPRECATED - Please use instead fetchTerrainAndTexture.

--- a/MapboxSceneKit/TerrainNode.swift
+++ b/MapboxSceneKit/TerrainNode.swift
@@ -41,6 +41,13 @@ open class TerrainNode: SCNNode {
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    @objc public convenience init(southWestCorner: CLLocationCoordinate2D, northEastCorner: CLLocationCoordinate2D) {
+        self.init(minLat: southWestCorner.latitude,
+                  maxLat: northEastCorner.latitude,
+                  minLon: southWestCorner.longitude,
+                  maxLon: northEastCorner.longitude)
+    }
 
     @objc public init(minLat: CLLocationDegrees, maxLat: CLLocationDegrees, minLon: CLLocationDegrees, maxLon: CLLocationDegrees) {
         assert(minLat >= -90.0 && minLat <= 90.0 && maxLat >= -90.0 && maxLat <= 90.0, "lats must be between -90.0 and 90.0")

--- a/MapboxSceneKit/TerrainNode.swift
+++ b/MapboxSceneKit/TerrainNode.swift
@@ -128,7 +128,7 @@ open class TerrainNode: SCNNode {
     @objc public func fetchTerrainAndTexture(minWallHeight: CLLocationDistance = 0.0, multiplier: Float = 1, enableDynamicShadows shadows: Bool = false, textureStyle style: String,
                                              heightProgress: MapboxImageAPI.TileLoadProgressCallback? = nil, heightCompletion: @escaping TerrainLoadCompletion,
                                              textureProgress: MapboxImageAPI.TileLoadProgressCallback? = nil, textureCompletion: @escaping MapboxImageAPI.TileLoadCompletion) {
-        let retryNumber = 3
+        let retryNumber = Constants.maxRequestAttempts
         fetchTerrainAndTexture(minWallHeight: minWallHeight,
                                multiplier: multiplier,
                                enableDynamicShadows: shadows,

--- a/MapboxSceneKit/TerrainNode.swift
+++ b/MapboxSceneKit/TerrainNode.swift
@@ -24,7 +24,7 @@ open class TerrainNode: SCNNode {
     fileprivate static let rgbTileSize = CGSize(width: 256, height: 256)
     fileprivate static let styleTileSize = CGSize(width: 256, height: 256)
 
-    private static let maxTextureImageSizeInBytes: Int = (1024 * 1024) // set a max texture size in order to dynamically calculate the highest zoom level for a given lat/lon bounding rect. Need to balance download speed and detail, so set to 1MB for now
+    private static let maxTextureImageSizeInBytes: Int = 2048 // set a max texture size in order to dynamically calculate the highest zoom level for a given lat/lon bounding rect. Need to balance download speed and detail, so set to 1MB for now
     private let initialTerrainZoomLevel: Int
 
     fileprivate var terrainSize: CGSize = CGSize.zero
@@ -57,7 +57,7 @@ open class TerrainNode: SCNNode {
         let minLocation = CLLocation(latitude: minLat, longitude: minLon)
         let distance = maxLocation.distance(from: minLocation) / 1000.0
 
-        initialTerrainZoomLevel = TerrainNode.zoomLevelAtLatitude(lat: maxLat - minLat, distance: distance)
+        initialTerrainZoomLevel = TerrainNode.zoomLevelAtLatitude(lat: maxLat, distance: distance)
         super.init()
         recalculateTerrainSize(forZoom: initialTerrainZoomLevel)
         geometry = SCNBox(width: CGFloat(metersPerX) * CGFloat(terrainSize.width), height: 10.0, length: CGFloat(metersPerY) * CGFloat(terrainSize.height), chamferRadius: 0.0)
@@ -72,12 +72,14 @@ open class TerrainNode: SCNNode {
 
     private class func zoomLevelAtLatitude(lat: Double, distance: Double) -> Int {
         // fit the zoom level to the screen width
-        let screenWidth = Double(UIScreen.main.bounds.size.width)
+        let screenWidth = Double(maxTextureImageSizeInBytes)
         let latitudinalAdjustment = cos(.pi * lat / 180)
         let earthDiameterInKilometers = 40075.16
         let arg = earthDiameterInKilometers * screenWidth * latitudinalAdjustment / (distance * 256)
-
-        return Int(round(log(arg)/log(2)))
+        
+        let zoom = Int(round(log(arg)/log(2)))
+        print(zoom)
+        return zoom
     }
 
     private func centerPivot() {


### PR DESCRIPTION
Cleans up some internals of TerrainNode without effecting any public APIs.

1. Update some variable names and code styling to improve readability.
1. Factor out math related to zoom level calculations.
1. Eliminate some code duplication between ImageAPI and TerrainNode.
1. Store some common parameters in a 'constants' struct.
1. Address #12.
1. Load style and terrain texture in parallel.