### PR TITLE
Update to Swift 4.2 and fix Memory Warning

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "4.0.2"
-github "mapbox/mapbox-events-ios" "v0.4.1"
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "4.4.1"
+github "mapbox/mapbox-events-ios" "v0.4.51"

--- a/MapboxSceneKit.xcodeproj/project.pbxproj
+++ b/MapboxSceneKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6862168C2164514C0016A678 /* unlit-line.metal in Resources */ = {isa = PBXBuildFile; fileRef = 957C85E42146FF92004C548E /* unlit-line.metal */; };
 		81293BEC20B4A1FB0014A17A /* MapboxSceneKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81A436BC20A1F68500F42A53 /* MapboxSceneKit.framework */; };
 		81293BF120B4A29C0014A17A /* MapboxSceneKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 81A436BC20A1F68500F42A53 /* MapboxSceneKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		81293BF320B4A35C0014A17A /* DemoStyleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81293BC920B4A1AE0014A17A /* DemoStyleViewController.swift */; };
@@ -35,7 +36,6 @@
 		9569513E2148827800D567AE /* DemoARViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 817BC08D20BDC071005A015D /* DemoARViewController.swift */; };
 		9569513F2148828200D567AE /* FocusSquare.swift in Sources */ = {isa = PBXBuildFile; fileRef = 817BC08F20BDC413005A015D /* FocusSquare.swift */; };
 		957C85E82146FF92004C548E /* PolylineShader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957C85E22146FF92004C548E /* PolylineShader.swift */; };
-		957C85E92146FF92004C548E /* unlit-line.metal in Sources */ = {isa = PBXBuildFile; fileRef = 957C85E42146FF92004C548E /* unlit-line.metal */; };
 		957C85EA2146FF92004C548E /* SCNProgramExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957C85E52146FF92004C548E /* SCNProgramExtensions.swift */; };
 		957C85EB2146FF92004C548E /* BezierSpline3D.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957C85E62146FF92004C548E /* BezierSpline3D.swift */; };
 		957C85EC2146FF92004C548E /* TerrainNodeExtension+Routes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957C85E72146FF92004C548E /* TerrainNodeExtension+Routes.swift */; };
@@ -301,16 +301,16 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1000;
 				ORGANIZATIONNAME = MapBox;
 				TargetAttributes = {
 					81293BD820B4A1C80014A17A = {
 						CreatedOnToolsVersion = 9.3.1;
-						LastSwiftMigration = 0940;
+						LastSwiftMigration = "";
 					};
 					81A436BB20A1F68500F42A53 = {
 						CreatedOnToolsVersion = 9.3;
-						LastSwiftMigration = 0930;
+						LastSwiftMigration = 1000;
 					};
 				};
 			};
@@ -348,6 +348,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6862168C2164514C0016A678 /* unlit-line.metal in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -411,7 +412,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				957C85E92146FF92004C548E /* unlit-line.metal in Sources */,
 				959F81622149DE9700A290DF /* PolylineRenderer.swift in Sources */,
 				95CC6AA4214ADB05000CD0E6 /* SCNExtensions.swift in Sources */,
 				81A436C820A1F6BC00F42A53 /* TerrainNode.swift in Sources */,
@@ -469,7 +469,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = GJZR2MEM28;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -498,7 +498,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = GJZR2MEM28;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -643,7 +643,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
@@ -667,7 +667,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -699,7 +699,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/MapboxSceneKit.xcodeproj/xcshareddata/xcschemes/MapboxSceneKit.xcscheme
+++ b/MapboxSceneKit.xcodeproj/xcshareddata/xcschemes/MapboxSceneKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxSceneKit/MapboxImageAPI.swift
+++ b/MapboxSceneKit/MapboxImageAPI.swift
@@ -157,7 +157,7 @@ public final class MapboxImageAPI: NSObject {
             }
 
             //Color data gets messed up if the user expectes a PNG back but doesn't get one
-            if format == MapboxImageAPI.TileImageFormatPNG, let image = imageBuilder.makeImage(), let png = UIImagePNGRepresentation(image), let formattedImage = UIImage(data: png) {
+            if format == MapboxImageAPI.TileImageFormatPNG, let image = imageBuilder.makeImage(), let png = image.pngData(), let formattedImage = UIImage(data: png) {
                 DispatchQueue.main.async {
                     completion(formattedImage, nil)
                 }

--- a/MapboxSceneKit/Tile Fetching/MapboxHTTPAPI.swift
+++ b/MapboxSceneKit/Tile Fetching/MapboxHTTPAPI.swift
@@ -26,9 +26,15 @@ enum FetchError: Int {
 }
 
 internal final class MapboxHTTPAPI {
+    
+    private static var dispatchQueue: DispatchQueue = {
+        let dispatchQueue = DispatchQueue(label: "com.mapbox.scenekit.api", attributes: [.concurrent])
+        return dispatchQueue
+    }()
+    
     private static var operationQueue: OperationQueue = {
         var operationQueue = OperationQueue()
-        operationQueue.underlyingQueue = DispatchQueue(label: "com.mapbox.scenekit.api", attributes: [.concurrent])
+        operationQueue.underlyingQueue = dispatchQueue
         operationQueue.name = "Mapbox API Queue"
         operationQueue.maxConcurrentOperationCount = 10
         return operationQueue


### PR DESCRIPTION
This PR updates the mapbox-scenekit project to Swift 4.2 and takes care of a warning being raised due to the `underlyingQueue` being weak. It stores a strong reference to the `dispatchQueue` being created in order to prevent deallocation.