### PR TITLE
Fix warning about unowned dispatch queue used to retrieve tile images.

### DIFF
--- a/MapboxSceneKit/Tile Fetching/MapboxHTTPAPI.swift
+++ b/MapboxSceneKit/Tile Fetching/MapboxHTTPAPI.swift
@@ -26,9 +26,10 @@ enum FetchError: Int {
 }
 
 internal final class MapboxHTTPAPI {
+    private static var tileDownloadTaskDispatchQueue = DispatchQueue(label: "com.mapbox.scenekit.api", attributes: [.concurrent])
     private static var operationQueue: OperationQueue = {
         var operationQueue = OperationQueue()
-        operationQueue.underlyingQueue = DispatchQueue(label: "com.mapbox.scenekit.api", attributes: [.concurrent])
+        operationQueue.underlyingQueue = tileDownloadTaskDispatchQueue
         operationQueue.name = "Mapbox API Queue"
         operationQueue.maxConcurrentOperationCount = 10
         return operationQueue


### PR DESCRIPTION
Ensure the dispatch queue used for image tile retrieval tasks is not deallocated due to an unowned variable.

This has been a warning for a while, but appears to actually break and cause crashes with apps built against Xcode 10.2