### PR TITLE
Dispatch queue and pending fetches crash fixes

### DIFF
--- a/MapboxSceneKit/Tile Fetching/MapboxHTTPAPI.swift
+++ b/MapboxSceneKit/Tile Fetching/MapboxHTTPAPI.swift
@@ -26,9 +26,10 @@ enum FetchError: Int {
 }
 
 internal final class MapboxHTTPAPI {
+    private static var tileDownloadTaskDispatchQueue = DispatchQueue(label: "com.mapbox.scenekit.api", attributes: [.concurrent])
     private static var operationQueue: OperationQueue = {
         var operationQueue = OperationQueue()
-        operationQueue.underlyingQueue = DispatchQueue(label: "com.mapbox.scenekit.api", attributes: [.concurrent])
+        operationQueue.underlyingQueue = tileDownloadTaskDispatchQueue
         operationQueue.name = "Mapbox API Queue"
         operationQueue.maxConcurrentOperationCount = 10
         return operationQueue


### PR DESCRIPTION
Wrap other cases where we mutate the pendingFetches array in the barrier queue.

Include fix to not release the DispatchQueue for tile image fetches.